### PR TITLE
Updates to source & selector paths

### DIFF
--- a/GitHub-Review-Filters/content/inject.js
+++ b/GitHub-Review-Filters/content/inject.js
@@ -23,7 +23,7 @@
         if (self.typeIsVisible[type]) {
           self.fileTypes[type].forEach(function(item) {
             if (self.isPulls) {
-              item.parent().parent().parent().hide();
+              item.parent().parent().parent().parent().hide();
             } else {
               item.parent().hide();
             }
@@ -33,7 +33,7 @@
         } else {
           self.fileTypes[type].forEach(function(item) {
             if (self.isPulls) {
-              item.parent().parent().parent().show();
+              item.parent().parent().parent().parent().show();
             } else {
               item.parent().show();
             }
@@ -112,21 +112,14 @@
       self.isEnterprise = $('body').hasClass('enterprise');
       self.isPulls = pathname[3] === 'pulls' || pathname[3] === 'issues';
       self.fileTypes = {};
-      self.searchStr = 'div.meta[data-path]';
-      self.allItemsSearchStr = 'div.meta[data-path]';
+      self.searchStr = 'div[data-path]';
+      self.allItemsSearchStr = 'div[data-path]';
       self.typeIsVisible = {};
       self.$ghHelperNavUl.find('li.toggleLink').remove();
       if (self.isPulls) {
-        // List of pull requests
-        if (self.isEnterprise) {
-          // enterprise github: search for @user mentions
-          self.searchStr = '.user-mention';
-          self.allItemsSearchStr = 'ul.pulls-list-group > li.list-group-item > .list-group-item-name';
-        } else {
-          // github.com: search for issue labels
-          self.searchStr = 'span.labels > a';
-          self.allItemsSearchStr = 'ul.table-list-issues > li.table-list-item > .issue-title';
-        }
+        // List of pull requests grouped by user's github handle
+        self.searchStr = '.opened-by > a';
+        self.allItemsSearchStr = 'ul.table-list-issues > li.table-list-item > .issue-title';
       }
       self.$allItems = $(self.allItemsSearchStr);
       $(self.searchStr).each(function() {

--- a/GitHub-Review-Filters/content/inject.js
+++ b/GitHub-Review-Filters/content/inject.js
@@ -1,101 +1,155 @@
-function GhHelper(){
-  var self = this;
-  var user = $('#user-links > li > a').text().trim();
-  var isPulls = window.location.pathname.split('/')[3] === 'pulls';
-  var $wrapper = $('body > div.wrapper');
-  var $header = $('div.wrapper > div.header');
-  var $content = $('div.wrapper > div.site');
-  $wrapper.addClass('gh-helper');
-  $header.after('<div id="ghHelperNav" class="'+$header.attr('class')+'"><div class="container clearfix"><ul class="top-nav"></ul></div></div>');
-  var $ghHelper = $('.gh-helper');
-  var $ghHelperNav = $('#ghHelperNav');
-  var $ghHelperNavUl = $ghHelperNav.find('div > ul.top-nav');
-  var $allItems = isPulls ? $('ul.pulls-list-group > li.list-group-item > .list-group-item-name') : $('div.meta[data-path]');
-  var typeIsVisible = {};
-  var $ghLegend;
-  self.addLink = function(fn, label) {
-    $('<li><a>'+label+'</a></li>')
-    .click(function() {
-      self[fn]();
-    })
-    .appendTo($ghHelperNavUl);
-  };
-  self.addToggleLink = function(type) {
-    var label = (isPulls?'':'.') + type;
-    $('<li class="toggleLink selected"><a>'+label+' ('+fileTypes[type].length+')</a></li>')
-    .click(function() {
-      if (typeIsVisible[type]) {
-        fileTypes[type].forEach(function(item) {
-          if (isPulls) {
-            item.parent().parent().parent().hide();
-          } else {
-            item.parent().hide();
-          }
-        });
-        typeIsVisible[type] = false;
-        $(this).removeClass('selected');
-      } else {
-        fileTypes[type].forEach(function(item) {
-          if (isPulls) {
-            item.parent().parent().parent().show();
-          } else {
-            item.parent().show();
-          }
-        });
-        typeIsVisible[type] = true;
-        $(this).addClass('selected');
+/*global jQuery:true*/
+/*global History:true*/
+(function($){
+  function GhHelper(){
+    var self = this;
+    self.$wrapper = $('body > div.wrapper');
+    self.$header = $('div.wrapper > div.header');
+    self.$content = $('div.wrapper > div.site');
+    self.$wrapper.addClass('gh-helper');
+
+    self.addLink = function(fn, label) {
+      $('<li><a>' + label + '</a></li>')
+      .click(function() {
+        self[fn]();
+      })
+      .appendTo(self.$ghHelperNavUl);
+    };
+
+    self.addToggleLink = function(type) {
+      var label = (self.isPulls ? '' : '.') + type;
+      $('<li class="toggleLink selected"><a>' + label + ' (' + self.fileTypes[type].length + ')</a></li>')
+      .click(function() {
+        if (self.typeIsVisible[type]) {
+          self.fileTypes[type].forEach(function(item) {
+            if (self.isPulls) {
+              item.parent().parent().parent().hide();
+            } else {
+              item.parent().hide();
+            }
+          });
+          self.typeIsVisible[type] = false;
+          $(this).removeClass('selected');
+        } else {
+          self.fileTypes[type].forEach(function(item) {
+            if (self.isPulls) {
+              item.parent().parent().parent().show();
+            } else {
+              item.parent().show();
+            }
+          });
+          self.typeIsVisible[type] = true;
+          $(this).addClass('selected');
+        }
+      })
+      .appendTo(self.$ghHelperNavUl);
+    };
+
+    self.addLegend = function() {
+      $('<li><a class="octicon octicon-info"></a><div id="ghLegend"><div class="arrow"></div><div class="gh-legend-title">GitHub Review Filters</div><div class="gh-legend-label"><div>Visible</div><div>Hidden</div></div><div class="gh-legend-img"></div></div></li>')
+      .appendTo(self.$ghHelperNavUl);
+      self.$ghLegend = self.$ghHelperNavUl.find('#ghLegend');
+      self.$ghHelperNav.find('.octicon').hover(function(){
+        self.$ghLegend.fadeIn();
+      }, function() {
+        self.$ghLegend.fadeOut();
+      });
+    };
+
+    self.addDivider = function() {
+      $('<div class="divider-vertical"></div>')
+      .appendTo(self.$ghHelperNavUl);
+    };
+
+    self.showAll = function() {
+      $(self.$allItems).parent().show();
+      Object.keys(self.typeIsVisible).forEach(function(type) {
+        self.typeIsVisible[type] = true;
+      });
+      self.$ghHelperNavUl.find('li.toggleLink').addClass('selected');
+    };
+
+    self.hideAll = function() {
+      $(self.$allItems).parent().hide();
+      Object.keys(self.typeIsVisible).forEach(function(type) {
+        self.typeIsVisible[type] = false;
+      });
+      self.$ghHelperNavUl.find('li.toggleLink').removeClass('selected');
+    };
+
+    self.init = function() {
+      var pathname = window.location.pathname.split('/');
+      self.isEnterprise = $('body').hasClass('enterprise');
+      self.isPulls = pathname[3] === 'pulls';
+      self.fileTypes = {};
+      self.searchStr = 'div.meta[data-path]';
+      self.typeIsVisible = {};
+      self.$header.after('<div id="ghHelperNav" class="' + self.$header.attr('class') + '"><div class="container clearfix"><ul class="top-nav"></ul></div></div>');
+      self.$ghHelper = $('.gh-helper');
+      self.$ghHelperNav = $('#ghHelperNav');
+      self.$ghHelperNavUl = self.$ghHelperNav.find('div > ul.top-nav');
+      self.$ghLegend = null;
+      self.addLegend();
+      self.addLink('showAll', 'Show All');
+      self.addLink('hideAll', 'Hide All');
+      self.addDivider();
+      self.update();
+      $('body').on('click', 'a.js-pull-request-tab', function updateClick() {
+        self.update();
+      });
+      $('body').on('click', 'a.issue-title-link', function updateClick() {
+        self.update();
+      });
+      $('body').on('DOMNodeInserted', '.wrapper > .site', function(e) {
+        if (!!e.target.className && (e.target.className.indexOf('view-pull-request') >= 0 || e.target.className.indexOf('issues-listing') >= 0)) {
+          self.update();
+        }
+      });
+    };
+
+    self.update = function() {
+      var pathname = window.location.pathname.split('/');
+      self.isEnterprise = $('body').hasClass('enterprise');
+      self.isPulls = pathname[3] === 'pulls' || pathname[3] === 'issues';
+      self.fileTypes = {};
+      self.searchStr = 'div.meta[data-path]';
+      self.allItemsSearchStr = 'div.meta[data-path]';
+      self.typeIsVisible = {};
+      self.$ghHelperNavUl.find('li.toggleLink').remove();
+      if (self.isPulls) {
+        // List of pull requests
+        if (self.isEnterprise) {
+          // enterprise github: search for @user mentions
+          self.searchStr = '.user-mention';
+          self.allItemsSearchStr = 'ul.pulls-list-group > li.list-group-item > .list-group-item-name';
+        } else {
+          // github.com: search for issue labels
+          self.searchStr = 'span.labels > a';
+          self.allItemsSearchStr = 'ul.table-list-issues > li.table-list-item > .issue-title';
+        }
       }
-    })
-    .appendTo($ghHelperNavUl);
-  };
-  self.addLegend = function() {
-    $('<li><a class="octicon octicon-info"></a><div id="ghLegend"><div class="arrow"></div><div class="gh-legend-title">GitHub Review Filters</div><div class="gh-legend-label"><div>Visible</div><div>Hidden</div></div><div class="gh-legend-img"></div></div></li>')
-    .appendTo($ghHelperNavUl);
-    $ghLegend = $ghHelperNavUl.find('#ghLegend');
-  };
-  self.addDivider = function() {
-    $('<div class="divider-vertical"></div>')
-    .appendTo($ghHelperNavUl);
-  };
-  self.showAll = function() {
-    $($allItems).parent().show();
-    Object.keys(typeIsVisible).forEach(function(type) {
-      typeIsVisible[type] = true;
-    });
-    $ghHelperNavUl.find('li.toggleLink').addClass('selected');
-  };
-  self.hideAll = function() {
-    $($allItems).parent().hide();
-    Object.keys(typeIsVisible).forEach(function(type) {
-      typeIsVisible[type] = false;
-    });
-    $ghHelperNavUl.find('li.toggleLink').removeClass('selected');
-  };
-  self.addLegend();
-  self.addLink('showAll', 'Show All');
-  self.addLink('hideAll', 'Hide All');
-  self.addDivider();
-  var fileTypes = {};
-  var searchStr = 'div.meta[data-path]';
-  if (isPulls) {
-    // List of pull requests
-    searchStr = '.user-mention';
+      self.$allItems = $(self.allItemsSearchStr);
+      $(self.searchStr).each(function() {
+        var fileType = self.isPulls ? $(this).text().trim() : $(this).attr('data-path').split('.').pop();
+        if (!self.fileTypes.hasOwnProperty(fileType)) {
+          self.fileTypes[fileType] = [];
+        }
+        self.typeIsVisible[fileType] = true;
+        self.fileTypes[fileType].push($(this));
+      });
+      Object.keys(self.fileTypes).forEach(function(fileType) {
+        self.addToggleLink(fileType);
+      });
+    };
+
+    self.init();
+
   }
-  $(searchStr).each(function() {
-    var fileType = isPulls ? $(this).text().trim() : $(this).attr('data-path').split('.').pop();
-    if (!fileTypes.hasOwnProperty(fileType)) {
-      fileTypes[fileType] = [];
-    }
-    typeIsVisible[fileType] = true;
-    fileTypes[fileType].push($(this));
+  $(document).ready(function() {
+    var ghHelper = new GhHelper();
+    $(window).bind('popstate', function() {
+      ghHelper.update();
+    });
+    ghHelper.update();
   });
-  Object.keys(fileTypes).forEach(function(fileType) {
-    self.addToggleLink(fileType);
-  });
-  $('#ghHelperNav > div > ul > li > .octicon').hover(function(){
-    $ghLegend.fadeIn();
-  }, function() {
-    $ghLegend.fadeOut();
-  });
-}
-var ghHelper = new GhHelper();
+}(jQuery));


### PR DESCRIPTION
Hi Larry,

The recent updates to Github broke your extension. This copies source from the browser extension. Not sure why I'm seeing different code in the browser vs. what's in master.

fixes:
- For a single pull request diff view
  - change `searchStr` and `allItemsSearchStr` to `'div[data-path]'`.
- For all pull requests view
  - only sort by `.opened-by > a` (user's github handle). `.user-mention` no longer works.
  - adjust jQuery parent reference for hiding/showing user's grouped pull requests.

Updated source in the first commit. The fixing change are made in my second commit.
